### PR TITLE
Streaming Component Rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1"
+  },
+  "dependencies": {
+    "make-synchronous": "^1.0.0"
   }
 }

--- a/packages/ansie/src/compiler/AnsieBuffer.ts
+++ b/packages/ansie/src/compiler/AnsieBuffer.ts
@@ -1,0 +1,53 @@
+
+
+export class AnsieBuffer {
+    _chunks: (Uint8Array | string)[] = []
+
+
+    write(c: Uint8Array | string): Promise<void> {
+        this._chunks.push(c);
+        return Promise.resolve();
+    }
+
+    encode(encoder: TextEncoder): Uint8Array {
+        const uint8Chunks = [];
+        for (const c of this._chunks) {
+            if (typeof c === 'string') {
+                uint8Chunks.push(encoder.encode(c))
+            } else if ("BYTES_PER_ELEMENT" in c && c.BYTES_PER_ELEMENT === 1) {
+                uint8Chunks.push(c)
+            } else {
+                throw new TypeError("expected Uint8Array or string, got " + c);
+            }
+        }
+
+        const outBuffer = new Uint8Array(uint8Chunks.reduce((sum, c) => sum + c.length, 0));
+        let offset = 0;
+        for (const c of uint8Chunks) {
+            outBuffer.set(c, offset);
+            offset += c.length;
+        }
+
+        return outBuffer;
+    }
+
+    asText({ binaryEncoder }: { binaryEncoder?: (encoder: Uint8Array) => void; } = {}): string {
+        let str = "";
+        for (const c of this._chunks) {
+            if (typeof c === 'string') {
+                str += c;
+            } else if ("BYTES_PER_ELEMENT" in c && c.BYTES_PER_ELEMENT === 1) {
+                if (binaryEncoder) {
+                    str += binaryEncoder(c);
+                } else {
+                    throw new Error("cannot stringify binary blob");
+                }
+            } else {
+                throw new TypeError("expected Uint8Array or string, got " + c);
+            }
+        }
+
+        return str;
+    }
+
+}

--- a/packages/ansie/src/compiler/compile.ts
+++ b/packages/ansie/src/compiler/compile.ts
@@ -6,22 +6,24 @@ import {
     type AnsieTheme,
     getGlobalTheme
 } from '../themes/themes';
+import { AnsieBuffer } from './AnsieBuffer';
+import makeSynchronous from 'make-synchronous';
+
+export type CompileConfig = {
+    markup: string;
+    theme?: AnsieTheme;
+    inputIncludesMarkdown?: boolean;
+    output?: CompilerFormat;
+};
 
 /**
  * Compiles the markup into a string.
  * @param optionsOrMarkup Options or the markup to compile (with default options)
  * @returns
  */
-export function compile(
-    optionsOrMarkup:
-        | string
-        | {
-              markup: string;
-              theme?: AnsieTheme;
-              inputIncludesMarkdown?: boolean;
-              output?: CompilerFormat;
-          }
-) {
+export async function compileAsync(
+    optionsOrMarkup: string | CompileConfig
+): Promise<string> {
     let theme = getGlobalTheme();
     let markup = '';
     let output: CompilerFormat = 'ansi';
@@ -40,8 +42,22 @@ export function compile(
         : parseAnsieMarkup(markup);
     if (ast) {
         const compiler = new Compiler(ast, theme || defaultTheme);
-        return compiler.compile({ format: output, theme });
+        const buffer = new AnsieBuffer();
+        await compiler.compile({ out: buffer, format: output, theme });
+        return buffer.asText();
     } else {
         return '';
     }
+}
+
+export function compile(
+    optionsOrMarkup: string | CompileConfig
+) {
+
+    const fn = makeSynchronous(async (url, optionsOrMarkup: string | CompileConfig) => {
+        const { default: ansie } = await import(url);
+        return await ansie.compileAsync(optionsOrMarkup);
+    });
+
+    return fn(import.meta.url, optionsOrMarkup);
 }

--- a/packages/ansie/src/compiler/node/block.ts
+++ b/packages/ansie/src/compiler/node/block.ts
@@ -1,4 +1,4 @@
-import { CompilerError, type CompilerFormat } from '../types';
+import { CompilerError, type AnsieWriter, type CompilerFormat } from '../types';
 import {
     type AnsieNode,
     AnsieNodeImpl,
@@ -21,17 +21,18 @@ import {
 
 export class BlockTextNodeImpl
     extends AnsieNodeImpl
-    implements TextNodeBase, SpaceNodeBase
-{
+    implements TextNodeBase, SpaceNodeBase {
     renderStart({
+        out,
         stack,
         format
     }: {
+        out: AnsieWriter,
         stack: AnsieNode[];
         format: CompilerFormat;
-    }) {
+    }): Promise<void> {
         if (format === 'ansi') {
-            return (
+            return out.write(
                 renderSpaceAttributesStart({
                     node: this._raw,
                     format,
@@ -44,7 +45,7 @@ export class BlockTextNodeImpl
                 })
             );
         } else if (format === 'markup') {
-            return renderNodeAsMarkupStart(this._raw);
+            return out.write(renderNodeAsMarkupStart(this._raw));
         } else {
             throw new CompilerError(
                 `Invalid format: ${format}`,
@@ -56,14 +57,16 @@ export class BlockTextNodeImpl
     }
 
     renderEnd({
+        out,
         stack,
         format = 'ansi'
     }: {
+        out: AnsieWriter,
         stack: AnsieNode[];
         format: CompilerFormat;
-    }) {
+    }): Promise<void> {
         if (format === 'ansi') {
-            return `${renderTextAttributesEnd({
+            return out.write(`${renderTextAttributesEnd({
                 style: this._style,
                 attributes: this._raw,
                 format
@@ -71,9 +74,9 @@ export class BlockTextNodeImpl
                 attributes: this._raw,
                 format,
                 style: this._style
-            })}`;
+            })}`);
         } else if (format === 'markup') {
-            return renderNodeAsMarkupEnd(this._raw);
+            return out.write(renderNodeAsMarkupEnd(this._raw));
         } else {
             throw new CompilerError(
                 `Invalid format: ${format}`,

--- a/packages/ansie/src/compiler/node/break.ts
+++ b/packages/ansie/src/compiler/node/break.ts
@@ -1,20 +1,22 @@
-import { CompilerError, type CompilerFormat } from '../types';
+import { CompilerError, type AnsieWriter, type CompilerFormat } from '../types';
 import { AnsieNodeImpl, type AnsieNode } from '../types';
 
 //// Break Node - This is a node that represents a line break
 
 export class BreakNodeImpl extends AnsieNodeImpl implements AnsieNode {
     renderStart({
+        out,
         stack,
         format
     }: {
+        out: AnsieWriter,
         stack: AnsieNode[];
         format: CompilerFormat;
-    }) {
+    }): Promise<void> {
         if (format === 'ansi') {
-            return '\n'.repeat(this._style?.spacing?.marginBottom || 1);
+            return out.write('\n'.repeat(this._style?.spacing?.marginBottom || 1));
         } else if (format === 'markup') {
-            return '<br/>';
+            return out.write('<br/>');
         }
 
         throw new CompilerError(
@@ -26,7 +28,5 @@ export class BreakNodeImpl extends AnsieNodeImpl implements AnsieNode {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    renderEnd() {
-        return '';
-    }
+    async renderEnd(): Promise<void> { }
 }

--- a/packages/ansie/src/compiler/node/inline.ts
+++ b/packages/ansie/src/compiler/node/inline.ts
@@ -10,7 +10,7 @@ import {
     renderTextAttributesEnd,
     renderTextAttributesStart
 } from '../../utilities/render-text-attributes';
-import { CompilerError, type CompilerFormat } from '../types';
+import { CompilerError, type AnsieWriter, type CompilerFormat } from '../types';
 import {
     AnsieNodeImpl,
     type TextNodeBase,
@@ -20,17 +20,18 @@ import {
 
 export class InlineTextNodeImpl
     extends AnsieNodeImpl
-    implements TextNodeBase, SpaceNodeBase
-{
+    implements TextNodeBase, SpaceNodeBase {
     renderStart({
+        out,
         stack,
         format
     }: {
+        out: AnsieWriter,
         stack: AnsieNode[];
         format: CompilerFormat;
-    }) {
+    }): Promise<void> {
         if (format === 'ansi') {
-            return (
+            return out.write(
                 renderSpaceAttributesStart({
                     node: this._raw,
                     format,
@@ -43,7 +44,7 @@ export class InlineTextNodeImpl
                 })
             );
         } else if (format === 'markup') {
-            return renderNodeAsMarkupStart(this._raw);
+            return out.write(renderNodeAsMarkupStart(this._raw));
         } else {
             throw new CompilerError(
                 `Invalid format: ${format}`,
@@ -55,14 +56,16 @@ export class InlineTextNodeImpl
     }
 
     renderEnd({
+        out,
         stack,
         format = 'ansi'
     }: {
+        out: AnsieWriter,
         stack: AnsieNode[];
         format: CompilerFormat;
     }) {
         if (format === 'ansi') {
-            return `${renderTextAttributesEnd({
+            return out.write(`${renderTextAttributesEnd({
                 style: this._style,
                 attributes: this._raw,
                 format
@@ -70,9 +73,9 @@ export class InlineTextNodeImpl
                 attributes: this._raw,
                 format,
                 style: this._style
-            })}`;
+            })}`);
         } else if (format === 'markup') {
-            return renderNodeAsMarkupEnd(this._raw);
+            return out.write(renderNodeAsMarkupEnd(this._raw));
         } else {
             throw new CompilerError(
                 `Invalid format: ${format}`,

--- a/packages/ansie/src/compiler/node/list.ts
+++ b/packages/ansie/src/compiler/node/list.ts
@@ -1,4 +1,4 @@
-import { CompilerError, type CompilerFormat } from '../types';
+import { CompilerError, type AnsieWriter, type CompilerFormat } from '../types';
 import { AnsieNodeImpl, type AnsieNode } from '../types';
 import {
     renderListAttributesEnd,
@@ -19,14 +19,16 @@ import {
 
 export class ListItemNodeImpl extends AnsieNodeImpl implements AnsieNode {
     renderStart({
+        out,
         stack,
         format
     }: {
+        out: AnsieWriter,
         stack: AnsieNode[];
         format: CompilerFormat;
-    }) {
+    }): Promise<void> {
         if (format === 'ansi') {
-            return (
+            return out.write(
                 renderSpaceAttributesStart({
                     node: this._raw,
                     format,
@@ -44,7 +46,7 @@ export class ListItemNodeImpl extends AnsieNodeImpl implements AnsieNode {
                 })
             );
         } else if (format === 'markup') {
-            return renderNodeAsMarkupStart(this._raw);
+            return out.write(renderNodeAsMarkupStart(this._raw));
         }
 
         throw new CompilerError(
@@ -56,13 +58,16 @@ export class ListItemNodeImpl extends AnsieNodeImpl implements AnsieNode {
     }
 
     renderEnd({
+        out,
+        stack,
         format = 'ansi'
     }: {
+        out: AnsieWriter,
         stack: AnsieNode[];
         format: CompilerFormat;
-    }) {
+    }): Promise<void> {
         if (format === 'ansi') {
-            return (
+            return out.write(
                 renderTextAttributesEnd({
                     style: this._style,
                     attributes: this._raw,
@@ -80,9 +85,14 @@ export class ListItemNodeImpl extends AnsieNodeImpl implements AnsieNode {
                 })
             );
         } else if (format === 'markup') {
-            return renderNodeAsMarkupEnd(this._raw);
-        } else {
-            return '';
+            return out.write(renderNodeAsMarkupEnd(this._raw));
         }
+
+        throw new CompilerError(
+            `Invalid format: ${format}`,
+            this._raw,
+            stack,
+            false
+        );
     }
 }

--- a/packages/ansie/src/compiler/node/raw.ts
+++ b/packages/ansie/src/compiler/node/raw.ts
@@ -1,14 +1,22 @@
-import type { CompilerFormat } from '../types';
+import type { AnsieWriter, CompilerFormat } from '../types';
 import { AnsieNodeImpl, type AnsieNode } from '../types';
 import { RawTextMutator } from '../../utilities/raw-text-mutator';
 
 export class RawTextNodeImpl extends AnsieNodeImpl implements AnsieNode {
-    renderStart({ format }: { stack: AnsieNode[]; format: CompilerFormat }) {
+    renderStart({
+        out,
+        stack,
+        format
+    }: {
+        out: AnsieWriter,
+        stack: AnsieNode[];
+        format: CompilerFormat;
+    }): Promise<void> {
         const text = this.attr('value') ?? '';
         if (format === 'markup') {
-            return text;
+            return out.write(text);
         } else {
-            return new RawTextMutator(text)
+            return out.write(new RawTextMutator(text)
                 .replaceEmoji()
                 .trimSpaces({
                     left: true,
@@ -16,11 +24,11 @@ export class RawTextNodeImpl extends AnsieNodeImpl implements AnsieNode {
                     allowNewLines: false,
                     replaceWithSingleSpace: true
                 })
-                .toString();
+                .toString());
         }
     }
 
-    renderEnd() {
-        return '';
+    async renderEnd(): Promise<void> {
+
     }
 }

--- a/packages/ansie/src/compiler/types.ts
+++ b/packages/ansie/src/compiler/types.ts
@@ -28,6 +28,10 @@ export enum ValidTags {
     'br' = 'br'
 }
 
+export interface AnsieWriter {
+    write(chunk: Uint8Array | string): Promise<void>
+}
+
 /**
  * A list of all the valid tags.  This is used by the parser to validate
  * the tags before returning the AST.
@@ -314,19 +318,23 @@ export abstract class AnsieNodeImpl {
     }
 
     abstract renderStart({
+        out,
         stack,
         format
     }: {
+        out: AnsieWriter,
         stack: AnsieNode[];
         format: CompilerFormat;
-    }): string;
+    }): Promise<void>;
     abstract renderEnd({
+        out,
         stack,
         format
     }: {
+        out: AnsieWriter,
         stack: AnsieNode[];
         format: CompilerFormat;
-    }): string;
+    }): Promise<void>;
 }
 
 /**
@@ -365,9 +373,8 @@ export class CompilerError implements Error {
      * @returns The string representation of the CompilerError.
      */
     toString() {
-        return `${this.name}: ${this.message} (${
-            this.markupNode.node
-        }, ${this.markupStack.map(node => node.node).join(', ')})`;
+        return `${this.name}: ${this.message} (${this.markupNode.node
+            }, ${this.markupStack.map(node => node.node).join(', ')})`;
     }
 
     /**

--- a/packages/ansie/src/index.ts
+++ b/packages/ansie/src/index.ts
@@ -1,4 +1,4 @@
-import { compile } from './compiler/compile';
+import { compile, compileAsync } from './compiler/compile';
 import { tpl } from './template';
 import { ansieConsole } from './console/console';
 import { getGlobalTheme, setGlobalTheme } from './themes/themes';
@@ -20,6 +20,7 @@ export default {
 
     // Compiler
     compile,
+    compileAsync,
     tpl,
     console: ansieConsole,
 


### PR DESCRIPTION
Allow a mixture of binary blobs and strings to be sent to the console using an async writer API, instead of compiling the whole output to a string then sending it. This (in theory, unimplemented) allows component renders to write directly to stdout.

It may be useful for implementing more complicated terminal extension components (i.e. images).

This is mostly a proof of concept. There are no docs, tests, and it introduces a new mostly unneeded dependency.