### PR TITLE
Fix markdown parsing bug in Ansie

### DIFF
--- a/src/utilities/convert-markdown-to-ansie.ts
+++ b/src/utilities/convert-markdown-to-ansie.ts
@@ -59,7 +59,8 @@ class AnsieRenderer extends Renderer {
         return checkbox.checked ? '[x]' : '[ ]';
     }
     paragraph(paragraph: Tokens.Paragraph): string {
-        return this.simplified ? paragraph.text : `<p>${paragraph.text}</p>`;
+        const content = this.parser.parseInline(paragraph.tokens);
+        return this.simplified ? content : `<p>${content}</p>`;
     }
     table(): string {
         return '';


### PR DESCRIPTION
## Summary
- handle inline tokens when rendering paragraphs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846b62ac0388326aa13921e95be374b